### PR TITLE
Added bubbles and balloons docs to LAMP docs

### DIFF
--- a/docs/09-data_science/02-data_types.md
+++ b/docs/09-data_science/02-data_types.md
@@ -31,6 +31,195 @@ Customizable surveys.
 ```json
 ```
 
+### 3D Figure Copy
+
+ActivitySpec: `lamp.3d_figure_copy`
+
+#### Description
+
+The 3D Figure drawing game.
+
+#### Settings
+
+#### Data 
+
+- `static_data`: 
+    - `point`: The associated point value with the completed session.	
+    - `drawn_file_name`: The link to the file containing the drawn image.	
+    - `game_name`: The unique game name for the drawing session.
+- `temporal_slices`:
+    - `item`: Unused.
+    - `value`: Unused.
+    - `type`: Unused.
+    - `duration`: Unused.
+    - `level`: Unused.
+
+#### Example
+
+```json
+```
+
+### Balloon Risk 
+
+ActivitySpec: `lamp.balloon_risk`
+
+#### Description
+
+The Balloon Risk test is a computerized assessment of risk-taking behavior. Participants click a button to continuously blow up a balloon until they either chose to "save their points" and move on to the next balloon or the balloon "pops" after being inflated too many times.
+
+#### Settings
+
+- `balloon_count`: Number of balloons the participant interacts with
+- `breakpoint_mean`: The average value the balloon will pop at
+- `breakpoint_std`: The standard deviation of the value the balloon will pop at.
+
+#### Data 
+
+- `static_data`:
+    - `points`: The associated point value with the completed session.
+- `balloon_count`: Number of balloons the participant interacts with
+- `breakpoint_mean`: The average value the balloon will pop at
+- `breakpoint_std`: The standard deviation of the value the balloon will pop at.	  
+- `temporal_slices`:
+    - `item`: Unused.
+    - `value`: Unused.
+    - `type`: Unused.
+    - `duration`: Unused.
+    - `level`: Unused.
+- `timestamp`: Unix timestamp (ms) of when the test began
+- `activity`: Alphanumeric id of the LAMP activity
+- `duration`: Total time spent on this activity
+
+#### Example
+
+```
+{'balloon_count': 15,
+   'breakpoint_mean': 64.5,
+   'breakpoint_std': 37,
+   'static_data': {'points': 55},
+   'temporal_slices': [{'duration': 1821,
+     'item': 1,
+     'level': 1,
+     'type': True,
+     'value': 1},
+    {'duration': 876, 'item': 2, 'level': 1, 'type': True, 'value': 1},
+    {'duration': 425, 'item': 3, 'level': 1, 'type': True, 'value': 1},
+    {'duration': 167, 'item': 8, 'level': 1, 'type': True, 'value': 1},
+    ...
+    {'duration': 128, 'item': 38, 'level': 1, 'type': True, 'value': 1},
+    {'duration': 145, 'item': 39, 'level': 1, 'type': True, 'value': 1},
+    {'duration': 135, 'item': 40, 'level': 1, 'type': True, 'value': 1},
+    {'duration': 154, 'item': 41, 'level': 1, 'type': True, 'value': 1},
+    {'duration': 1724, 'item': 1, 'level': 2, 'type': True, 'value': 1},
+    
+    {'duration': 160, 'item': 2, 'level': 2, 'type': True, 'value': 1},
+    {'duration': 158, 'item': 3, 'level': 2, 'type': True, 'value': 1},
+    {'duration': 306, 'item': 4, 'level': 2, 'type': True, 'value': 1},
+    ...
+    {'duration': 176, 'item': 73, 'level': 2, 'type': True, 'value': 1},
+    {'duration': 151, 'item': 74, 'level': 2, 'type': True, 'value': 1},
+    {'duration': 178, 'item': 75, 'level': 2, 'type': True, 'value': 1},
+    {'duration': 161, 'item': 76, 'level': 2, 'type': False, 'value': 0},
+    {'duration': 5602, 'item': 1, 'level': 3, 'type': True, 'value': 1},
+    {'duration': 2588, 'item': 1, 'level': 4, 'type': True, 'value': 1},
+    ...
+    {'duration': 809, 'item': 1, 'level': 15, 'type': True, 'value': 1}],
+   'timestamp': 1642779164213,
+   'duration': 78365,
+   'activity': '8vw829aemgdxy8f1fvk9'}
+```    
+
+### Cats & Dogs
+
+ActivitySpec: `lamp.cats_and_dogs` & `lamp.cats_and_dogs_new`
+
+#### Description
+
+The Cats and Dogs game.
+
+#### Settings
+
+#### Data 
+
+- `static_data`:
+    - `point`: The associated point value with the completed session.	
+    - `rating`:	The associated rating of the completed session.	
+    - `correct_answers`: The total number of correct answers made in the session.	
+    - `wrong_answers`: The total number of incorrect answers made in the session.	
+    - `total_questions`: The total number of questions encountered during the session.    
+- `temporal_slices`:
+    - `item`: Unused.
+    - `value`: Unused.
+    - `type`: Unused.
+    - `duration`: Unused.
+    - `level`: Unused.
+
+#### Example
+
+```json
+```
+
+
+### Digit Span
+
+ActivitySpec: `lamp.digit_span`
+
+#### Description
+
+The Digit Span test, with Forward and Backward variants.
+
+#### Settings
+
+#### Data 
+
+- `static_data`: 
+    - `rating`: The associated rating of the completed session.	
+    - `score`: The computed score for the completed session.	
+    - `correct_answers`: The total number of correct answers made in the session.	
+    - `wrong_answers`: The total number of incorrect answers made in the session.	
+    - `type`: The integer indicating forward or backward variant.
+- `temporal_slices`:
+    - `item`: Unused.
+    - `value`: Unused.
+    - `type`: Unused.
+    - `duration`: Unused.
+    - `level`: Unused.
+
+#### Example
+
+```json
+```
+
+
+### Jewels
+
+ActivitySpec: `lamp.jewels_a` & `lamp.jewels_b`
+
+#### Description
+
+The Jewels game, with variants A & B.
+
+#### Settings
+
+#### Data 
+
+- `static_data`: 
+    - `point`: (number) The associated point value with the completed session. 
+    - `rating`: (number) The associated rating of the completed session.
+    - `score`: (number) The computed score for the completed session.
+    - `total_attempts`: (number) The total number of attempts made during the session.
+- `temporal_slices`:
+    - `item`: (number) Unused.
+    - `value`: (string) The alphanumeric index of the item tapped.
+    - `type`: (string) Whether the correct item was tapped or not ("correct" or "none").
+    - `duration`: (number) Unused.
+    - `level`: (number) Unused.
+
+#### Example
+
+```json
+```
+
 ### N-Back
 
 ActivitySpec: `lamp.nback` & `lamp.nback_new`
@@ -61,24 +250,74 @@ The NBack test.
 ```json
 ```
 
-### Spatial Span
+### Pop The Bubbles
 
-ActivitySpec: `lamp.spatial_span`
+ActivitySpec: `lamp.pop_the_bubbles`
 
 #### Description
 
-The Spatial Span test, with Forward and Backward variants.
+A sustained attention task where the user is instructed to pop various sequences of bubbles according to varying rulesets.
+
+### Settings
+- `bubble_count: number[] = [60, 80, 80]`: number of bubbles per level; array length = number of levels, must match below array's length
+- `bubble_speed: number[] = [30, 30, 30]`: speed at which bubbles enter level in seconds; array length = number of levels, must match above array's length
+- `intertrial_duration: number = 0.5`: duration between trials, in seconds
+- `bubble_duration: number = 1.0`: length of time bubbles remain on screen, in seconds
+
+
+### Data
+- `static_data`: Unused
+
+- `temporal_slices`
+    - `item: number`: the index of the bubble in the current level (Currently bugged: just shows the order of bubbles popped - i.e. the fifth bubble popped will have 5 for this value)
+    - `value: string`: the color of the bubble (i.e. `yellow`, `red`, etc.) followed by trial type (i.e. `go`, `no-go`, `no-go-lure`, `no-go-constant`, `no-go-2inrow`).
+    - `type: boolean`: whether this tap was correct or incorrect
+    - `level: number`: the level number
+    - `duration: number`: the reaction time to tap the bubble, in milliseconds, or `null` if bubble ignored (Currently bugged: not present)
+- `timestamp`: Unix timestamp (ms) of when the test began
+- `activity`: Alphanumeric id of the LAMP activity
+- `duration`: Total time spent on this activity
+
+#### Example
+```
+{'duration': 46083,
+   'static_data': {},
+   'temporal_slices': [{'item': 1,
+     'level': 1,
+     'type': True,
+     'value': 'blue go'},
+    {'item': 2, 'level': 1, 'type': True, 'value': 'pink go'},
+    {'item': 3, 'level': 1, 'type': False, 'value': 'red no-go'},
+    {'item': 1, 'level': 2, 'type': True, 'value': 'blue go'},
+    {'item': 2, 'level': 2, 'type': True, 'value': 'yellow go'},
+    {'item': 3, 'level': 2, 'type': True, 'value': 'blue go'},
+    {'item': 4, 'level': 2, 'type': True, 'value': 'yellow go'},
+    {'item': 1, 'level': 3, 'type': True, 'value': 'blue go'},
+    {'item': 2, 'level': 3, 'type': False, 'value': 'green no-go-constant'},
+    {'item': 3, 'level': 3, 'type': True, 'value': 'yellow no-go-2inrow'},
+    {'item': 4, 'level': 3, 'type': True, 'value': 'blue go'}],
+   'timestamp': 1642777640745,
+   'activity': '3ztmvcbragc20a6sew4b'}
+```
+
+### Serial 7s
+
+ActivitySpec: `lamp.serial_7s`
+
+#### Description
+
+The Serial 7s test.
 
 #### Settings
 
 #### Data 
 
-- `static_data`:
+- `static_data`: Unused.
     - `rating`: The associated rating of the completed session.	
     - `score`: The computed score for the completed session.	
-    - `correct_answers`: The total number of correct answers made in the session.	
-    - `wrong_answers`: The total number of incorrect answers made in the session.	
-    - `type`: The integer indicating forward or backward variant.
+    - `total_attempts`: The total number of attempts made during the session.	
+    - `total_questions`: The total number of questions encountered during the session.	
+    - `version`: The version of the test played.  
 - `temporal_slices`:
     - `item`: Unused.
     - `value`: Unused.
@@ -121,137 +360,19 @@ The Simple Memory test.
 ```json
 ```
 
-### Serial 7s
+### Spatial Span
 
-ActivitySpec: `lamp.serial_7s`
-
-#### Description
-
-The Serial 7s test.
-
-#### Settings
-
-#### Data 
-
-- `static_data`: Unused.
-    - `rating`: The associated rating of the completed session.	
-    - `score`: The computed score for the completed session.	
-    - `total_attempts`: The total number of attempts made during the session.	
-    - `total_questions`: The total number of questions encountered during the session.	
-    - `version`: The version of the test played.  
-- `temporal_slices`:
-    - `item`: Unused.
-    - `value`: Unused.
-    - `type`: Unused.
-    - `duration`: Unused.
-    - `level`: Unused.
-
-#### Example
-
-```json
-```
-
-### Cats & Dogs
-
-ActivitySpec: `lamp.cats_and_dogs` & `lamp.cats_and_dogs_new`
+ActivitySpec: `lamp.spatial_span`
 
 #### Description
 
-The Cats and Dogs game.
+The Spatial Span test, with Forward and Backward variants.
 
 #### Settings
 
 #### Data 
 
 - `static_data`:
-    - `point`: The associated point value with the completed session.	
-    - `rating`:	The associated rating of the completed session.	
-    - `correct_answers`: The total number of correct answers made in the session.	
-    - `wrong_answers`: The total number of incorrect answers made in the session.	
-    - `total_questions`: The total number of questions encountered during the session.    
-- `temporal_slices`:
-    - `item`: Unused.
-    - `value`: Unused.
-    - `type`: Unused.
-    - `duration`: Unused.
-    - `level`: Unused.
-
-#### Example
-
-```json
-```
-
-### 3D Figure Copy
-
-ActivitySpec: `lamp.3d_figure_copy`
-
-#### Description
-
-The 3D Figure drawing game.
-
-#### Settings
-
-#### Data 
-
-- `static_data`: 
-    - `point`: The associated point value with the completed session.	
-    - `drawn_file_name`: The link to the file containing the drawn image.	
-    - `game_name`: The unique game name for the drawing session.
-- `temporal_slices`:
-    - `item`: Unused.
-    - `value`: Unused.
-    - `type`: Unused.
-    - `duration`: Unused.
-    - `level`: Unused.
-
-#### Example
-
-```json
-```
-
-### Visual Association
-
-ActivitySpec: `lamp.visual_association`
-
-#### Description
-
-The Visual Association test.
-
-#### Settings
-
-#### Data 
-
-- `static_data`:
-    - `rating`: The associated rating of the completed session.	
-    - `score`: The computed score for the completed session.	
-    - `total_attempts`:	The total number of attempts made during the session.	
-    - `total_questions`: The total number of questions encountered during the session.	
-    - `version`: The version of the test played.
-- `temporal_slices`:
-    - `item`: Unused.
-    - `value`: Unused.
-    - `type`: Unused.
-    - `duration`: Unused.
-    - `level`: Unused.
-
-#### Example
-
-```json
-```
-
-### Digit Span
-
-ActivitySpec: `lamp.digit_span`
-
-#### Description
-
-The Digit Span test, with Forward and Backward variants.
-
-#### Settings
-
-#### Data 
-
-- `static_data`: 
     - `rating`: The associated rating of the completed session.	
     - `score`: The computed score for the completed session.	
     - `correct_answers`: The total number of correct answers made in the session.	
@@ -328,35 +449,36 @@ The new dot-touch variant of the Trails B test.
 ```json
 ```
 
-### Jewels
 
-ActivitySpec: `lamp.jewels_a` & `lamp.jewels_b`
+### Visual Association
+
+ActivitySpec: `lamp.visual_association`
 
 #### Description
 
-The Jewels game, with variants A & B.
+The Visual Association test.
 
 #### Settings
 
 #### Data 
 
-- `static_data`: 
-    - `point`: (number) The associated point value with the completed session. 
-    - `rating`: (number) The associated rating of the completed session.
-    - `score`: (number) The computed score for the completed session.
-    - `total_attempts`: (number) The total number of attempts made during the session.
+- `static_data`:
+    - `rating`: The associated rating of the completed session.	
+    - `score`: The computed score for the completed session.	
+    - `total_attempts`:	The total number of attempts made during the session.	
+    - `total_questions`: The total number of questions encountered during the session.	
+    - `version`: The version of the test played.
 - `temporal_slices`:
-    - `item`: (number) Unused.
-    - `value`: (string) The alphanumeric index of the item tapped.
-    - `type`: (string) Whether the correct item was tapped or not ("correct" or "none").
-    - `duration`: (number) Unused.
-    - `level`: (number) Unused.
+    - `item`: Unused.
+    - `value`: Unused.
+    - `type`: Unused.
+    - `duration`: Unused.
+    - `level`: Unused.
 
 #### Example
 
 ```json
 ```
-
 ## Sensor Types
 
 Active sensor events are produced on a rolling basis via interactions by a Participant. They are transferred to the **Platform Server** automatically by using the Activity API written in JavaScript. By “beginning” and “ending” a recording of these interactions, as well as “emitting” temporal data during the interaction, an ActivityEvent can be captured and sent to the **Platform Server**. A list of existing Sensors is provided below with name and description; a live server instance must be consulted for data schema information (see GET /sensor_spec). Implementations for these hardware sensors are provided in the GitHub repository.


### PR DESCRIPTION
This commit adds docs for the 'Pop the Bubbles' and "Balloon Risk" tasks to the LAMP docs
Additionally, to improve readability and better match the displays in the dashboard, activities have been alphabetized.