### PR TITLE
Correct Docs favicon path

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "title": "LAMP Platform",
     "tagline": "The LAMP Platform documentation.",
     "url": "https://docs.lamp.digital",
-    "favicon": "./docs/assets/logo.png",
+    "favicon": "./static/logo.png",
     "organizationName": "BIDMCDigitalPsychiatry",
     "projectName": "LAMP-platform",
     "baseUrl": "/",


### PR DESCRIPTION
Currently favicon for the docs points to an incorrect location. This results in a 404 error in the console and no icon appearing in the tab.

![image](https://github.com/user-attachments/assets/fb937684-0bac-4208-af18-9eb6ee65b677)

The logo.png file does exist, it has just moved. This update points favicon to the correct path.