### PR TITLE
Fix favicon path for Docusaurus

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "title": "LAMP Platform",
     "tagline": "The LAMP Platform documentation.",
     "url": "https://docs.lamp.digital",
-    "favicon": "./static/logo.png",
+    "favicon": "/logo.png",
     "organizationName": "BIDMCDigitalPsychiatry",
     "projectName": "LAMP-platform",
     "baseUrl": "/",


### PR DESCRIPTION
I forgot how the static folder works. This should hopefully actually fix the favicon path.