### PR TITLE
Updated year in copyright to 2025.

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
       "footer": {
         "style": "dark",
         "links": [],
-        "copyright": "2024 LAMP Consortium & Division of Digital Psychiatry @ BIDMC"
+        "copyright": "2025 LAMP Consortium & Division of Digital Psychiatry @ BIDMC"
       }
     },
     "presets": [


### PR DESCRIPTION
Commit to change update banner with "2024 LAMP Consortium & Division of Digital Psychiatry @ BIDMC".