### PR TITLE
Remove mentions of the LAMP Forum from the documentation

### DIFF
--- a/blog/2022-1-11.md
+++ b/blog/2022-1-11.md
@@ -9,7 +9,7 @@ author_image_url: https://avatars.githubusercontent.com/u/96262286?v=4
 
 :::danger
 
-Server administrators MUST upgrade from `:2021` to `:2022` versions in the Docker configuration. Please contact us on the forum if there are any questions.
+Server administrators MUST upgrade from `:2021` to `:2022` versions in the Docker configuration.
 
 :::
 

--- a/docs/02-quick_links/02-bug.md
+++ b/docs/02-quick_links/02-bug.md
@@ -4,4 +4,4 @@ slug: /bug
 
 # Report issues
 
-If you encounter any issues with the app, please check out our community forum: https://mindlamp.discourse.group/
+If you encounter any issues with the app, please fill out our feedback form [here](https://docs.google.com/forms/d/e/1FAIpQLSdyt4olypT86pN9GLoueuawR_XUJwlDLo_HhSpIGTZ2Q7sn2g/viewform?usp=dialog)

--- a/docs/08-develop/07-app_gateway.md
+++ b/docs/08-develop/07-app_gateway.md
@@ -42,7 +42,7 @@ External collaborators are **NOT PERMITTED** to use `mailto:`, `sms:`, or `slack
 
 To allow external collaborators to send push notifications to users' iOS and Android devices, the following steps must be completed: 
 1. collaborator organization must complete the consortium enrollment form
-2. collaborator organization must make the request for an API Key **on the community forum** (emailed requests **ARE NOT PERMITTED**)
+2. collaborator organization must make the request for an API Key
 3. a BIDMC team member must save this information to the `Projects → LAMP Platform → Documents → People Pipeline → Consortium Members` database in the internal team Notion.
 4. the BIDMC team member must generate a new API Key in the terminal using this command: `openssl rand -base64 12`
      1. An API Key is actually just a randomly generated string to uniquely identify an external collaborator, and contains no other information.

--- a/docs/08-develop/12-Training Modules/01-training-modules.md
+++ b/docs/08-develop/12-Training Modules/01-training-modules.md
@@ -1644,7 +1644,7 @@ We use the following scheme to manage issues and releases:
 4. **Release**: Represents two sprints worth of issues (work items) that constitute a monthly release of each of the components of the LAMP Platform.
     1. When creating a release (i.e. on `LAMP-server`), collect all the pull requests/commits merged since the last release and create a well-formatted summary list of changes.
     2. The release version MUST be the current date in the format `YYYY.MM.DD` (e.g. `2021.6.1`).
-    3. The CI/CD pipeline will take care of the rest! Be sure to post the update to the [docs.lamp.digital](http://docs.lamp.digital) What's New page, as well as to the community forum (below).
+    3. The CI/CD pipeline will take care of the rest! Be sure to post the update to the [docs.lamp.digital](http://docs.lamp.digital) What's New page.
 5. **Project**: Represents the evolving nature of the entire LAMP Platform, encompassing all past and future releases. 
     1. The GitHub Project board should contain all triaged issues (work items) that are actively important for our team to take care of, but not ones that are not important to us.
 
@@ -1652,16 +1652,6 @@ We use the following scheme to manage issues and releases:
 🌟 Tip: linking a GitHub issue or PR in one repository from another entirely separate repository allows GitHub to show that in-line with the comments.
 
 </aside>
-
----
-
-### Using the LAMP Community Forum
-
-`~5 minutes`
-
-If you're assisting with triaging issues/working with collaborators, or doing data analysis using the LAMP Platform, **be sure to register for an account on the forum here.** In case collaborators post questions, it's important we answer them. 
-
-[LAMP Consortium](https://mindlamp.discourse.group)
 
 ---
 

--- a/docs/11-troubleshooting.md
+++ b/docs/11-troubleshooting.md
@@ -1,8 +1,8 @@
 # Troubleshooting
 
-In case your app is running into issues or you have questions regarding setting up, see this section to see if the solutions listed help! If you are a collaborator or a researcher using mindLAMP, please post on our community forums [here](https://mindlamp.discourse.group/). If you are still in need of further assistance, please file a report through our bug reporting form [here](https://docs.google.com/forms/d/e/1FAIpQLSdy354xNzQVekizuSMePWk_F7YGl9ENencXKJ-T0oo4ZTNkaA/viewform).
+In case your app is running into issues or you have questions regarding setting up, see this section to see if the solutions listed help! If you are still in need of further assistance, please file a report through our bug reporting form [here](https://docs.google.com/forms/d/e/1FAIpQLSdyt4olypT86pN9GLoueuawR_XUJwlDLo_HhSpIGTZ2Q7sn2g/viewform?usp=dialog).
 
-You can also access these links from within the app after logging in and clicking the person icon in the top right corner. Clicking on 'Help and Support' will take you to this documentation page and clicking 'LAMP Community' will take you to the community forums if you are a collaborator and having problems with the app. The 'Contact Us' button will allow you to email us in case you are encountering a unique issue that was unable to be solved after viewing the documentation and posting on the community forums. See the image of where to click to access these links below.
+You can also access these links from within the app after logging in and clicking the person icon in the top right corner. Clicking on 'Help and Support' will take you to this documentation page. The 'Contact Us' button will allow you to email us in case you are encountering a unique issue that was unable to be solved after viewing the documentation. See the image of where to click to access these links below.
 
 ![](assets/profile.png)
 

--- a/package.json
+++ b/package.json
@@ -122,10 +122,6 @@
             "position": "right",
             "items": [
               {
-                "label": "Forum",
-                "href": "https://mindlamp.discourse.group/"
-              },
-              {
                 "label": "GitHub",
                 "href": "https://github.com/BIDMCDigitalPsychiatry/LAMP-platform/"
               },


### PR DESCRIPTION
Recently the LAMP Forum was archived due to lack of use. However our documentation still contained many references to the forum which now point at a dead link. This is a first pass PR to remove references to the Forum from the docs.