### PR TITLE
Reimplement Local Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/plugin-content-docs": "3.6.0",
         "@docusaurus/preset-classic": "^3.7.0",
-        "@easyops-cn/docusaurus-search-local": "^0.45.0",
+        "@easyops-cn/docusaurus-search-local": "^0.48.5",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "docusaurus-plugin-openapi": "^0.7.6",

--- a/package.json
+++ b/package.json
@@ -175,6 +175,15 @@
           "path": "./LAMP-protocol/openapi.yml",
           "routeBasePath": "api"
         }
+      ],
+      [
+        "@easyops-cn/docusaurus-search-local",
+        {
+          "indexDocs": true,
+          "indexBlog": false,
+          "indexPages": false,
+          "hashed": true
+        }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "lamp-platform",
   "version": "0.0.0",
   "private": true,
+  "overrides": {
+    "@docusaurus/theme-common": "3.7.0"
+  },
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/plugin-content-docs": "3.6.0",
     "@docusaurus/preset-classic": "^3.7.0",
-    "@easyops-cn/docusaurus-search-local": "^0.45.0",
+    "@easyops-cn/docusaurus-search-local": "^0.48.5",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "docusaurus-plugin-openapi": "^0.7.6",


### PR DESCRIPTION
While completing the API update, Doc search was disabled. This PR attempts to reenable documentation search. 

In response to issue: https://github.com/BIDMCDigitalPsychiatry/LAMP-platform/issues/889