### PR TITLE
Revert to last working version for docusaurus local search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/plugin-content-docs": "3.6.0",
         "@docusaurus/preset-classic": "^3.7.0",
-        "@easyops-cn/docusaurus-search-local": "^0.48.5",
+        "@easyops-cn/docusaurus-search-local": "^0.45.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "docusaurus-plugin-openapi": "^0.7.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/plugin-content-docs": "3.6.0",
     "@docusaurus/preset-classic": "^3.7.0",
-    "@easyops-cn/docusaurus-search-local": "^0.48.5",
+    "@easyops-cn/docusaurus-search-local": "^0.45.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "docusaurus-plugin-openapi": "^0.7.6",
@@ -183,8 +183,8 @@
         "@easyops-cn/docusaurus-search-local",
         {
           "indexDocs": true,
-          "indexBlog": false,
-          "indexPages": false,
+          "indexBlog": true,
+          "indexPages": true,
           "hashed": true
         }
       ]


### PR DESCRIPTION
- Reverted `@easyops-cn/docusaurus-search-local"` to version `0.45.0`
- Added Indexing for Blogs and Pages