### PR TITLE
docs: Remove redundant header element

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,26 +91,6 @@
         },
         "items": [
           {
-            "label": "User Guide",
-            "position": "left",
-            "to": "/",
-            "activeBaseRegex": "/([0-9a-zA-Z]+)",
-            "items": [
-              {
-                "label": "Download App",
-                "to": "/app"
-              },
-              {
-                "label": "Report Bug",
-                "to": "/bug"
-              },
-              {
-                "label": "FAQ",
-                "to": "/faq"
-              }
-            ]
-          },
-          {
             "label": "API",
             "position": "left",
             "to": "/api"


### PR DESCRIPTION
Remove User Guide section from navbar: Removes the User Guide dropdown menu from the documentation site navigation bar, keeping only the API and Community links.

Reasoning: The User Guide content is redundant with quick links and  is poorly named which causes confusion for users navigating the documentation.