### PR TITLE
Add Health Connect Integration Examples page

### DIFF
--- a/docs/06-developer/04-extending/05-health-connect-integration-examples.md
+++ b/docs/06-developer/04-extending/05-health-connect-integration-examples.md
@@ -1,6 +1,4 @@
 ---
-unlisted: true
-slug: /health-connect-integration-examples
 title: Health Connect Integration Examples
 description: How mindLAMP integrates Health Connect data with mental-health context to deliver meaningful insights in the participant portal.
 ---

--- a/docs/06-developer/04-extending/index.mdx
+++ b/docs/06-developer/04-extending/index.mdx
@@ -17,6 +17,7 @@ mindLAMP can be extended beyond its built-in capabilities with custom content, a
   <DocCard id="developer/extending/interventions" />
   <DocCard id="developer/extending/cron-jobs" />
   <DocCard id="developer/extending/oauth-oidc" />
+  <DocCard id="developer/extending/health-connect-integration-examples" />
 </DocCardGrid>
 
 ## General Approach


### PR DESCRIPTION
## Summary
- Adds a new docs page covering how mindLAMP integrates Health Connect data with mental-health context (mood, anxiety, sleep quality, validated clinical scales) to power participant-portal visualizations via LAMP-cortex.
- Lists the page under **Developer → Extending mindLAMP** as the 5th entry and registers it in the section's `DocCardGrid`.

## Test plan
- [ ] `npm run build` succeeds with no broken-link or sidebar errors
- [ ] Local preview shows the page in the sidebar under Developer → Extending mindLAMP, after OAuth/OIDC
- [ ] Page renders at `/developer/extending/health-connect-integration-examples`
- [ ] Extending mindLAMP landing page shows a card for the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)